### PR TITLE
Fixed numpy not being installed on pip install

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,9 @@ setup(
     version="0.0.2",
     author="Saurabh Aone",
     packages=find_packages(),
+    install_requires=[
+        "numpy",
+    ],
     description= "Whalegrad - A Lightweight Deep Learning Framework",
     license="MIT",
     


### PR DESCRIPTION
Hey! I know you are currently not working on this project, though still liked the project and wanted to try. While trying realised that it asks us to install numpy too while creating venv. Anyway nice project. If you had a thought that who tf am I, then I know you from Atharv Porate, the guy who accidentally unstarred your repo.